### PR TITLE
Add Arc dark theme

### DIFF
--- a/Themes/arc-dark.json
+++ b/Themes/arc-dark.json
@@ -1,0 +1,25 @@
+{
+  "name": "Arc Dark",
+  "comment": "https://github.com/horst3180/arc-theme ported by @jcf",
+  "use-theme-colors": false,
+  "foreground-color": "#cccccc",
+  "background-color": "#29303a",
+  "palette": [
+    "#2E3436",
+    "#DC322F",
+    "#27ae60",
+    "#f39c12",
+    "#268BD2",
+    "#9933CC",
+    "#33CC99",
+    "#EEE8D5",
+    "#555753",
+    "#E84F4F",
+    "#2ecc71",
+    "#f1c40f",
+    "#6699FF",
+    "#CC66FF",
+    "#93A1A1",
+    "#FDF6E3"
+  ]
+}


### PR DESCRIPTION
I've just added this theme to my setup by porting copying over the contents of my Xresources. Thought someone else might be interested so figured I'd add the theme to the repo.

![2018-08-21-22 21 45-d03d47555680](https://user-images.githubusercontent.com/18374/44429810-9ea09d80-a590-11e8-881f-f4a7dcdaf7f7.png)
