### PR TITLE
feat: add github dark theme

### DIFF
--- a/Themes/github-dark.json
+++ b/Themes/github-dark.json
@@ -1,0 +1,25 @@
+{
+    "name": "GitHub Dark",
+    "comment": "Ported for Terminix Colour Scheme",
+    "use-theme-colors": false,
+    "foreground-color": "#D1D5DA",
+    "background-color": "#1F2328",
+    "palette": [
+        "#586069",
+        "#EA495A",
+        "#33D057",
+        "#FFEA7F",
+        "#2087FF",
+        "#B392F0",
+        "#39C5CF",
+        "#D1D5DA",
+        "#959DA5",
+        "#F97582",
+        "#85E89D",
+        "#FFEA7F",
+        "#79B7FF",
+        "#B392F0",
+        "#56D4DD",
+        "#FAFBFC"
+    ]
+}


### PR DESCRIPTION
Added the dark variant of the GitHub color scheme.

![Screenshot_20221227_171413](https://user-images.githubusercontent.com/59823800/209686337-8d4df07d-3731-4e11-83b0-308035f73439.png)
